### PR TITLE
feat: check response cookie's length

### DIFF
--- a/app/middleware/session.js
+++ b/app/middleware/session.js
@@ -1,5 +1,27 @@
 'use strict';
 
+const compose = require('koa-compose');
+
 module.exports = (options, app) => {
-  return require('koa-session')(options, app);
+  const cookieSessionMatchKey = `${options.key}=`;
+  return compose([
+    function* checkCookieLength(next) {
+      yield next;
+      const setCookie = this.response.headers['set-cookie'];
+      if (!setCookie) {
+        return;
+      }
+      for (const val of setCookie) {
+        // http://browsercookielimits.squawky.net/
+        if (val.indexOf(cookieSessionMatchKey) === 0 && val.length > 4093) {
+          const err = new Error(`Max cookie limit is 4093, but got ${val.length}`);
+          err.name = 'CookieLimitExceedError';
+          err.cookie = val;
+          this.coreLogger.error(err);
+          break;
+        }
+      }
+    },
+    require('koa-session')(options, app),
+  ]);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cookie"
   ],
   "dependencies": {
+    "koa-compose": "^2.5.1",
     "koa-session": "^3.4.0"
   },
   "devDependencies": {
@@ -31,6 +32,8 @@
     "egg-mock": "^1.1.0",
     "eslint": "^3.9.1",
     "eslint-config-egg": "^3.1.0",
+    "intelli-espower-loader": "^1.0.1",
+    "power-assert": "^1.4.2",
     "should": "^11.1.1",
     "supertest": "^2.0.1"
   },
@@ -38,10 +41,9 @@
     "node": ">=4.0.0"
   },
   "scripts": {
-    "test": "npm run lint -- --fix&& npm run test-local",
-    "test-local": "egg-bin test",
-    "cov": "egg-bin cov",
     "lint": "eslint .",
+    "test": "npm run lint -- --fix&& egg-bin test -r intelli-espower-loader",
+    "cov": "egg-bin cov -r intelli-espower-loader",
     "ci": "npm run lint && npm run cov",
     "autod": "autod"
   },

--- a/test/fixtures/large-cookie-session/app/router.js
+++ b/test/fixtures/large-cookie-session/app/router.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function(app) {
+  app.get('/', function* () {
+    this.session = {
+      key: 'a'.repeat(3000),
+    };
+    this.body = this.session;
+  });
+};

--- a/test/fixtures/large-cookie-session/package.json
+++ b/test/fixtures/large-cookie-session/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "large-cookie-session"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Max cookie length is 4093

http://browsercookielimits.squawky.net/