### PR TITLE
fix: should export sessionStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ egg-session support external store, you can store your sessions in redis, memcac
 
 For example, if you want to store session in redis, you must:
 
-1. Dependent [egg-redis](https://github.com/eggjs/egg-redis)
+1. Dependent [@eggjs/redis](https://github.com/eggjs/redis)
 
   ```bash
-  npm i --save egg-redis
+  npm i --save @eggjs/redis
   ```
 
-2. Import egg-redis as a plugin and set the configuration
+2. Import `@eggjs/redis` as a plugin and set the configuration
 
   ```js
   // config/plugin.js
   exports.redis = {
     enable: true,
-    package: 'egg-redis',
+    package: '@eggjs/redis',
   };
   ```
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">= 18.19.0"
   },
   "dependencies": {
-    "@eggjs/core": "^6.2.13",
+    "@eggjs/core": "^6.3.1",
     "koa-session": "^7.0.2",
     "zod": "^3.24.1"
   },
@@ -37,12 +37,12 @@
     "@arethetypeswrong/cli": "^0.17.1",
     "@eggjs/bin": "7",
     "@eggjs/mock": "^6.0.5",
+    "@eggjs/redis": "^3.0.0",
     "@eggjs/supertest": "^8.2.0",
     "@eggjs/tsconfig": "1",
     "@types/mocha": "10",
     "@types/node": "22",
-    "egg": "^4.0.1",
-    "egg-redis": "^2.6.0",
+    "egg": "^4.0.3",
     "eslint": "8",
     "eslint-config-egg": "14",
     "rimraf": "6",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,15 @@
 import type { SessionConfig } from './config/config.default.js';
+import type { SessionStoreOrAppSessionStoreClass, SessionStore } from './app/extend/application.js';
 
 declare module '@eggjs/core' {
   // add EggAppConfig overrides types
   interface EggAppConfig {
     session: SessionConfig;
+  }
+
+  interface EggCore {
+    // add EggCore instance property
+    set sessionStore(store: SessionStoreOrAppSessionStoreClass | null | undefined);
+    get sessionStore(): SessionStore | undefined;
   }
 }

--- a/test/fixtures/redis-session/config/plugin.js
+++ b/test/fixtures/redis-session/config/plugin.js
@@ -1,6 +1,4 @@
-'use strict';
-
 exports.redis = {
   enable: true,
-  package: 'egg-redis',
+  package: '@eggjs/redis',
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md to reflect new Redis package naming from `egg-redis` to `@eggjs/redis`
	- Updated installation and configuration instructions

- **Dependencies**
	- Updated `@eggjs/core` to version 6.3.1
	- Added `@eggjs/redis` version 3.0.0
	- Updated `egg` to version 4.0.3
	- Removed `egg-redis` package

- **Type Changes**
	- Added session store configuration methods to `EggCore` interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->